### PR TITLE
Support PKGBUILD with git source

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,10 +33,6 @@ if [ -f .SRCINFO ] && ! sudo -u builder makepkg --printsrcinfo | diff - .SRCINFO
 	exit 1
 fi
 
-# Get array of packages to be built
-mapfile -t PKGFILES < <( sudo -u builder makepkg --packagelist )
-echo "Package(s): ${PKGFILES[*]}"
-
 # Optionally install dependencies from AUR
 if [ -n "${INPUT_AURDEPS:-}" ]; then
 	# First install yay
@@ -57,6 +53,10 @@ fi
 # INPUT_MAKEPKGARGS is intentionally unquoted to allow arg splitting
 # shellcheck disable=SC2086
 sudo -H -u builder makepkg --syncdeps --noconfirm ${INPUT_MAKEPKGARGS:-}
+
+# Get array of packages to be built
+mapfile -t PKGFILES < <( sudo -u builder makepkg --packagelist )
+echo "Package(s): ${PKGFILES[*]}"
 
 # Report built package archives
 i=0


### PR DESCRIPTION
Using the `pkgbuild-action` with a git PKGBUILD fails as the `makepkg --packagelist` is executed before the `makepkg`.
The  `makepkg` will update `pkgver` to the last git commit, thus the package will not have the same name as stored in the `PKGFILES` var : 

```
==> Finished making: darktable-git 3.5.0.r2425.gf3fc325d39-1 (Tue 01 Jun 2021 11:19:05 PM UTC)
Archive darktable-git-3.5.0.r2340.gc9011b818b-1-x86_64.pkg.tar.zst not built
```