### PR TITLE
Generate .SRCINFO if it doesn't exist + Improve readability of .SRCINFO diff

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ cd "${INPUT_PKGDIR:-.}"
 # Assume that if .SRCINFO is missing then it is generated elsewhere.
 # AUR checks that .SRCINFO exists so a missing file can't go unnoticed.
 sudo -u builder makepkg --printsrcinfo > .SRCINFO.expected
-if [ -f .SRCINFO ] && ! diff .SRCINFO.expected .SRCINFO; then
+if [ -f .SRCINFO ] && ! diff -u --color=always .SRCINFO.expected .SRCINFO; then
 	echo "::error file=$FILE,line=$LINENO::Mismatched .SRCINFO. Update with: makepkg --printsrcinfo > .SRCINFO"
 	exit 1
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,10 +28,12 @@ cd "${INPUT_PKGDIR:-.}"
 
 # Assume that if .SRCINFO is missing then it is generated elsewhere.
 # AUR checks that .SRCINFO exists so a missing file can't go unnoticed.
-if [ -f .SRCINFO ] && ! sudo -u builder makepkg --printsrcinfo | diff - .SRCINFO; then
+sudo -u builder makepkg --printsrcinfo > .SRCINFO.expected
+if [ -f .SRCINFO ] && ! diff .SRCINFO.expected .SRCINFO; then
 	echo "::error file=$FILE,line=$LINENO::Mismatched .SRCINFO. Update with: makepkg --printsrcinfo > .SRCINFO"
 	exit 1
 fi
+mv .SRCINFO.expected .SRCINFO
 
 # Optionally install dependencies from AUR
 if [ -n "${INPUT_AURDEPS:-}" ]; then


### PR DESCRIPTION
- Handle case where .SRCINFO is missing by generating the .SRCINFO.
- Improve readability of .SRCINFO diffs using color and unified diff format.