### PR TITLE
Fix permissions of files by changing owner to builder user

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,12 @@ if [ -n "${INPUT_AURDEPS:-}" ]; then
 	sudo -H -u builder yay --sync --noconfirm "${PKGDEPS[@]}"
 fi
 
+# Make the builder user the owner of these files
+# Without this, (e.g. only having every user have read/write access to the files), 
+# makepkg will try to change the permissions of the files itself which will fail since it does not own the files/have permission
+# we can't do this earlier as it will change files that are for github actions, which results in warnings in github actions logs.
+chown -R builder .
+
 # Build packages
 # INPUT_MAKEPKGARGS is intentionally unquoted to allow arg splitting
 # shellcheck disable=SC2086


### PR DESCRIPTION
Found this when trying to use this action for this PKGBUILD: https://github.com/wwmm/easyeffects/blob/1aae2d16ac1972c41eb9df8b91f2c1b0c8a4d9b9/PKGBUILD

Without this later on makepkg tries to change the owner itself, which fails:

```
chmod: changing permissions of '/github/workspace/src': Operation not permitted
==> ERROR: An unknown error has occurred. Exiting...
/entrypoint.sh: line 55:   297 User defined signal 1   sudo -H -u builder makepkg --syncdeps --noconfirm ${INPUT_MAKEPKGARGS:-}
```

I’m not entirely sure why other repositories wouldn’t have been affected by this though. 