### PR TITLE
Add the ability to create a makeshift Arch Linux repository in GitHub releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux:latest
+FROM archlinux:base-devel
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: "Relative path to directory containing the PKGBUILD file."
     required: false
     default: "."
+  pacmanConf:
+    description: "Relative path to alternative configuration file for pacman"
+    required: false
+    default: "/etc/pacman.conf"
   aurDeps:
     description: "Support AUR dependencies if nonempty."
     required: false
@@ -29,6 +33,10 @@ inputs:
     description: "Additional arguments to pass to makepkg."
     required: false
     default: ""
+  makepkgConf:
+    description: "Relative path to alternative configuration file for makepkg"
+    required: false
+    default: "/etc/makepkg.conf"
   repoReleaseTag:
     description: "Tag to use as repository name"
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -29,11 +29,23 @@ inputs:
     description: "Additional arguments to pass to makepkg."
     required: false
     default: ""
+  repoReleaseTag:
+    description: "Tag to use as repository name"
+    required: false
+    default: ""
 outputs:
   pkgfile0:
     description: "Filename of the first generated package archive. Usually only one."
   pkgfile1:
     description: "Filename of the 2nd generated package archive, etc."
+  repofile0:
+    description: "<repoReleaseTag>.db"
+  repofile1:
+    description: "<repoReleaseTag>.db.tar.gz"
+  repofile2:
+    description: "<repoReleaseTag>.files"
+  repofile3:
+    description: "<repoReleaseTag>.files.tar.gz"
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yaml
+++ b/action.yaml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: "."
   pacmanConf:
-    description: "Relative path to alternative configuration file for pacman"
+    description: "Relative path to alternative configuration file for pacman."
     required: false
     default: "/etc/pacman.conf"
   aurDeps:
@@ -34,11 +34,15 @@ inputs:
     required: false
     default: ""
   makepkgConf:
-    description: "Relative path to alternative configuration file for makepkg"
+    description: "Relative path to alternative configuration file for makepkg."
     required: false
     default: "/etc/makepkg.conf"
+  multilib:
+    description: "Install 'multilib-devel' to build lib32 packages."
+    required: false
+    default: false
   repoReleaseTag:
-    description: "Tag to use as repository name"
+    description: "Tag to use as repository name."
     required: false
     default: ""
 outputs:

--- a/action.yaml
+++ b/action.yaml
@@ -49,7 +49,19 @@ outputs:
   pkgfile0:
     description: "Filename of the first generated package archive. Usually only one."
   pkgfile1:
-    description: "Filename of the 2nd generated package archive, etc."
+    description: "Filename of the 2nd generated package archive."
+  pkgfile2:
+    description: "Filename of the 3rd generated package archive."
+  pkgfile3:
+    description: "Filename of the 4th generated package archive. etc."
+  oldfile0:
+    description: "Filename of the first removed package archive. Usually only one."
+  oldfile1:
+    description: "Filename of the 2nd removed package archive."
+  oldfile2:
+    description: "Filename of the 3rd removed package archive."
+  oldfile3:
+    description: "Filename of the 4th removed package archive. etc."
   repofile0:
     description: "<repoReleaseTag>.db"
   repofile1:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,8 +31,6 @@ pacman -Syu --noconfirm --needed base base-devel
 pacman -Syu --noconfirm --needed ccache
 #pacman -Syu --noconfirm --needed ccache-ext
 
-export CCACHE_DIR="./.ccache"
-
 if [ "${INPUT_MULTILIB:-false}" == true ]; then
 	pacman -Syu --noconfirm --needed multilib-devel
 fi
@@ -100,7 +98,7 @@ chown -R builder .
 # Build packages
 # INPUT_MAKEPKGARGS is intentionally unquoted to allow arg splitting
 # shellcheck disable=SC2086
-sudo -H -u builder makepkg --syncdeps --noconfirm ${INPUT_MAKEPKGARGS:-}
+sudo -H -u builder CCACHE_DIR="$BASEDIR/.ccache" makepkg --syncdeps --noconfirm ${INPUT_MAKEPKGARGS:-}
 
 # Get array of packages to be built
 # shellcheck disable=SC2086

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,10 @@ function download_database () {
     # This is put here to fail early in case they weren't downloaded
     REPOFILES=("${INPUT_REPORELEASETAG:-}".{db{,.tar.gz},files{,.tar.gz}})
     for REPOFILE in "${REPOFILES[@]}"; do
-        sudo -u builder curl -Lf -o "$REPOFILE" "$GITHUB_SERVER_URL"/"$GITHUB_REPOSITORY"/releases/download/"${INPUT_REPORELEASETAG:-}"/"$REPOFILE"
+        sudo -u builder curl \
+            --retry 5 --retry-delay 30 --retry-all-errors \
+            --location --fail \
+            -o "$REPOFILE" "$GITHUB_SERVER_URL"/"$GITHUB_REPOSITORY"/releases/download/"${INPUT_REPORELEASETAG:-}"/"$REPOFILE"
     done
     # Delete the `<repo_name>.db` and `repo_name.files` symlinks
     rm "${INPUT_REPORELEASETAG:-}".{db,files} || true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -96,7 +96,8 @@ chown -R builder .
 sudo -H -u builder makepkg --syncdeps --noconfirm ${INPUT_MAKEPKGARGS:-}
 
 # Get array of packages to be built
-mapfile -t PKGFILES < <( sudo -u builder makepkg --packagelist )
+# shellcheck disable=SC2086
+mapfile -t PKGFILES < <( sudo -u builder makepkg --packagelist ${INPUT_MAKEPKGARGS:-})
 echo "Package(s): ${PKGFILES[*]}"
 
 if [ -n "${INPUT_REPORELEASETAG:-}" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -124,7 +124,7 @@ for PKGFILE in "${PKGFILES[@]}"; do
 	RELPKGFILE="$(realpath --relative-base="$BASEDIR" "$PKGFILE")"
 	# Caller arguments to makepkg may mean the pacakge is not built
 	if [ -f "$PKGFILE" ]; then
-		echo "::set-output name=pkgfile$i::$RELPKGFILE"
+		echo "pkgfile$i=$RELPKGFILE" >> $GITHUB_OUTPUT
         # Optionally add the packages to a makeshift repository in GitHub releases
         if [ -n "${INPUT_REPORELEASETAG:-}" ]; then
             sudo -u builder repo-add "${INPUT_REPORELEASETAG:-}".db.tar.gz "$(basename "$PKGFILE")"
@@ -147,7 +147,7 @@ if [ -n "${INPUT_REPORELEASETAG:-}" ]; then
     j=0
     for REPOFILE in "${REPOFILES[@]}"; do
         RELREPOFILE="$(realpath --relative-base="$BASEDIR" "$(realpath -s "$REPOFILE")")"
-        echo "::set-output name=repofile$j::$RELREPOFILE"
+        echo "repofile$j=$RELREPOFILE" >> $GITHUB_OUTPUT
     (( ++j ))
     done
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -95,6 +95,17 @@ echo "Package(s): ${PKGFILES[*]}"
 # Report built package archives
 i=0
 for PKGFILE in "${PKGFILES[@]}"; do
+    # Replace colon (:) in files name because releases don't like it
+    # It seems to not mess with pacman so it doesn't need to be guarded
+    set -x
+    srcdir="$(dirname "$PKGFILE")"
+    srcfile="$(basename "$PKGFILE")"
+    if [ "$srcfile" == *:* ]; then
+        dest="$srcdir/${srcfile//:/.}"
+        mv "$PKGFILE" "$dest"
+        PKGFILE="$dest"
+    fi
+    set +x
 	# makepkg reports absolute paths, must be relative for use by other actions
 	RELPKGFILE="$(realpath --relative-base="$BASEDIR" "$PKGFILE")"
 	# Caller arguments to makepkg may mean the pacakge is not built

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,12 +36,7 @@ fi
 # Optionally install dependencies from AUR
 if [ -n "${INPUT_AURDEPS:-}" ]; then
 	# First install yay
-	pacman -S --noconfirm --needed git
-	git clone https://aur.archlinux.org/yay-bin.git /tmp/yay
-	pushd /tmp/yay
-	chmod -R a+rw .
-	sudo -H -u builder makepkg --syncdeps --install --noconfirm
-	popd
+	pacman -Syu --noconfirm yay
 
 	# Extract dependencies from .SRCINFO (depends or depends_x86_64) and install
 	mapfile -t PKGDEPS < \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,11 @@ if [ -n "${INPUT_MAKEPKGCONF:-}" ]; then
     cp "${INPUT_MAKEPKGCONF:-}" /etc/makepkg.conf
 fi
 
-pacman -Syu --noconfirm --needed base-devel
+pacman -Syu --noconfirm --needed base base-devel
+
+if [ "${INPUT_MULTILIB:-false}" == true ]; then
+    pacman -Syu --noconfirm --needed multilib-devel
+fi
 
 # Makepkg does not allow running as root
 # Create a new user `builder`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,8 @@ pacman -Syu --noconfirm --needed base base-devel
 pacman -Syu --noconfirm --needed ccache
 #pacman -Syu --noconfirm --needed ccache-ext
 
+export CCACHE_DIR="./.ccache"
+
 if [ "${INPUT_MULTILIB:-false}" == true ]; then
 	pacman -Syu --noconfirm --needed multilib-devel
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,14 @@ cat << EOM >> /etc/pacman.conf
 Include = /etc/pacman.d/mirrorlist
 EOM
 
+# Add alerque repository for paru
+cat << EOM >> /etc/pacman.conf
+[alerque]
+SigLevel = Optional TrustAll
+Server = https://arch.alerque.com/\$arch
+EOM
+pacman-key --recv-keys 63CC496475267693
+
 pacman -Syu --noconfirm --needed base-devel
 
 # Makepkg does not allow running as root
@@ -35,13 +43,13 @@ fi
 
 # Optionally install dependencies from AUR
 if [ -n "${INPUT_AURDEPS:-}" ]; then
-	# First install yay
-	pacman -Syu --noconfirm yay
+	# First install paru
+	pacman -Syu --noconfirm paru
 
 	# Extract dependencies from .SRCINFO (depends or depends_x86_64) and install
 	mapfile -t PKGDEPS < \
 		<(sed -n -e 's/^[[:space:]]*\(make\)\?depends\(_x86_64\)\? = \([[:alnum:][:punct:]]*\)[[:space:]]*$/\3/p' .SRCINFO)
-	sudo -H -u builder yay --sync --noconfirm "${PKGDEPS[@]}"
+	sudo -H -u builder paru --sync --noconfirm "${PKGDEPS[@]}"
 fi
 
 # Make the builder user the owner of these files

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,8 @@ if [ -n "${INPUT_MAKEPKGCONF:-}" ]; then
 fi
 
 pacman -Syu --noconfirm --needed base base-devel
+pacman -Syu --noconfirm --needed ccache
+#pacman -Syu --noconfirm --needed ccache-ext
 
 if [ "${INPUT_MULTILIB:-false}" == true ]; then
 	pacman -Syu --noconfirm --needed multilib-devel


### PR DESCRIPTION
The goal of this PR is to add the necessary bits to generate the files (`<reponame>.{db,db.tar.gz,files.file.tar.gz}`) that constitute an Arch Linux repository.

The way it works is by updating the repository files and exposing them in the action outputs to be uploaded. It also allows for custom `pacman` and `makepkg` configuration files to pull dependencies from releases.

You can see it in use in my own repo here https://github.com/loathingKernel/PKGBUILDs

I am opening this as a draft to see if there is any interest in merging it and as a RFC. If this is something that could be included, I am will update the documentation too to reflect the changes.

The  yay -> paru change or downloading it from `alerque` repository are not mandatory and I will exclude them from the final PR if they are not wanted.